### PR TITLE
Better toxicity filtering by reporting instead of immediately deleting & muting

### DIFF
--- a/src/controllers/ToxicityController.ts
+++ b/src/controllers/ToxicityController.ts
@@ -4,14 +4,14 @@ import { ToxicityClassifier, load } from "@tensorflow-models/toxicity";
 import Controller from "../structures/Controller";
 import ValClient from "../ValClient";
 
-import { warn, mute, isWarned } from "../utils/moderation";
 import { log } from "../utils/general";
+import { createEmbed } from "../utils/embed";
+import { getChannelObject } from "../utils/object";
 
 export default class ToxicityController extends Controller {
 	ready = false;
-	labels: string[] = [];
+	labels: Record<string, string>;
 	threshold = 0.7;
-	confidence = 0.95;
 	classifier: ToxicityClassifier;
 
 	constructor(client: ValClient) {
@@ -19,67 +19,90 @@ export default class ToxicityController extends Controller {
 			name: "toxicity",
 		});
 
-		this.labels = [
-			"identity_attack",
-			"severe_toxicity",
-			"threat",
-			"insult",
-			"obscene",
-			"sexual_explicit",
-			"toxicity",
-		];
+		this.labels = {
+			identity_attack: "Identity Attack",
+			insult: "Insult",
+			obscene: "Obscenity",
+			severe_toxicity: "Severe Toxicity",
+			sexual_explicit: "Sexually Explicit Content",
+			threat: "Threats",
+			toxicity: "Toxicity",
+		};
 	}
 
 	init = async () => {
-		if (process.env.MODE !== "DEVELOPMENT")
-			load(this.threshold, this.labels).then(model => {
-				this.classifier = model;
-				this.ready = true;
+		if (process.env.MODE === "DEVELOPMENT") return;
 
-				log(this.client, "ToxicityController loaded successfully", "info");
-			});
+		load(this.threshold, Object.keys(this.labels)).then(model => {
+			this.classifier = model;
+			this.ready = true;
+
+			log(this.client, "ToxicityController loaded successfully", "info");
+		});
 	};
 
-	classify = async (message: Message) => {
-		if (!this.ready) return false;
+	classify = async (message: Message): Promise<string[]> => {
+		if (!this.ready) return [];
 
 		const { content: sentence } = message;
 		const predictions = await this.classifier.classify([sentence]);
 
-		return predictions.reduce(
-			(result, curr) =>
-				curr.results[0].match === true &&
-				curr.results[0].probabilities[1] > this.confidence
-					? true
-					: result,
-			false,
-		);
+		return predictions
+			.filter(prediction => prediction.results.some(result => result.match))
+			.map(prediction => prediction.label);
 	};
 
-	handleToxic = async (message: Message): Promise<void> => {
-		const { author, channel } = message;
-		const reason = "Used toxic language";
+	report = async (message: Message, predictions: string[]): Promise<void> => {
+		const { author, id, channel, content } = message;
+		const modLogsChannel = getChannelObject(
+			this.client,
+			this.client.config.CHANNEL_MOD_LOGS,
+		);
 
-		if (isWarned(this.client, author.id)) {
-			await message.reply("دي تاني مرة تقل ادبك. ادي اخرتها. mute.");
-			await mute(this.client, {
-				member: author.id,
-				moderator: this.client.user.id,
-				channel: channel.id,
-				reason,
-			});
+		const url = `https://discord.com/channels/${this.client.ValGuild.id}/${channel.id}/${id}`;
+		const fields = [
+			{
+				name: "Message Content",
+				value: content,
+			},
+			{
+				name: "Author",
+				value: `<@${author.id}>`,
+			},
+			{
+				name: "Author Member ID",
+				value: `${author.id}`,
+			},
+			{
+				name: "Involved Members",
+				value:
+					message.mentions.members
+						.map(member => member.toString())
+						.join("\n") || "None",
+			},
+			{
+				name: "Violations",
+				value: predictions
+					.map(prediction => this.labels[prediction])
+					.join("\n"),
+			},
+			{
+				name: "Message Link",
+				value: url,
+			},
+		];
 
-			message.delete({ reason });
-		} else {
-			await message.reply("متبقوش توكسيك. ده تحذير, المره الجاية mute.");
-			await warn(this.client, {
-				member: author.id,
-				moderator: this.client.user.id,
-				channel: channel.id,
-				reason,
-			});
+		const report = createEmbed({
+			title: `Spectre Report - Rule Violation`,
+			description: `Possible violations by ${author.tag}`,
+			url,
+			fields,
+			footer: {
+				text:
+					"You can safely ignore this report if you think it's made in error",
+			},
+		});
 
-			message.delete({ reason });
-		}
+		await modLogsChannel.send(report);
 	};
 }

--- a/src/listeners/MessageListener.ts
+++ b/src/listeners/MessageListener.ts
@@ -26,9 +26,12 @@ export default class MessageListener extends Listener {
 				controllers.get("conversation")
 			);
 
-			const isToxic = await toxicity.classify(message);
+			const classification = await toxicity.classify(message);
 
-			if (isToxic) return toxicity.handleToxic(message);
+			if (classification.length > 0) {
+				toxicity.report(message, classification);
+				return;
+			}
 
 			const isClientMentioned =
 				mentions.members &&
@@ -59,6 +62,7 @@ export default class MessageListener extends Listener {
 		member,
 	}: Message): boolean =>
 		!webhookID &&
+		this.client.ready &&
 		author.id !== this.client.user.id &&
 		channel.type === "text" &&
 		type === "DEFAULT" &&


### PR DESCRIPTION
This PR introduces breaking changes. It replaces the old toxicity filtering algorithm that immediately deletes a potentially toxic message and mutes the author, and instead report it to the `CHANNEL_MOD_LOGS` channel for human mods to verify. 

Reasons
- Some links (gifs) have obscene links/names, and get users muted for that
- Some songs have obscene names, and also get users muted

So even if I ignored links, people could exploit that to send obscene messages formatted as links. Same goes for the second point. 