### PR TITLE
Fix: Toxicity Filter shouldn't prevent message handling 

### DIFF
--- a/src/listeners/MessageListener.ts
+++ b/src/listeners/MessageListener.ts
@@ -28,10 +28,8 @@ export default class MessageListener extends Listener {
 
 			const classification = await toxicity.classify(message);
 
-			if (classification.length > 0) {
-				toxicity.report(message, classification);
-				return;
-			}
+			if (classification.length > 0) 
+				await toxicity.report(message, classification);
 
 			const isClientMentioned =
 				mentions.members &&


### PR DESCRIPTION
Removed line 33, and removed the curly brackets surrounding this block, and added await before line 32